### PR TITLE
Use WebSockets to ask clients to refresh the page when timers are updated

### DIFF
--- a/RallyTimer/asgi.py
+++ b/RallyTimer/asgi.py
@@ -9,8 +9,15 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
 
 import os
 
+from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
+import timer.routing
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'RallyTimer.settings')
 
-application = get_asgi_application()
+application = ProtocolTypeRouter({
+    'http': get_asgi_application(),
+      'websocket': URLRouter(
+      timer.routing.websocket_urlpatterns
+      ),
+})

--- a/RallyTimer/settings.py
+++ b/RallyTimer/settings.py
@@ -36,7 +36,9 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'daphne',
     'django.contrib.staticfiles',
+    'channels',
     'timer',
 ]
 
@@ -69,6 +71,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'RallyTimer.wsgi.application'
+ASGI_APPLICATION = 'RallyTimer.asgi.application'
 
 
 # Database
@@ -123,3 +126,9 @@ STATICFILES_DIRS = [ BASE_DIR / 'static']
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    },
+}

--- a/static/main.js
+++ b/static/main.js
@@ -7,6 +7,22 @@ const countdownBox = document.getElementById('timeleft')
 const timerDate = Date.parse(timerDateBox.textContent)
 const timerDurationSplit = timerDurationBox.textContent.split(':')
 const timerDuration = (+timerDurationSplit[0] * 60 * 60 * 1000) + (+timerDurationSplit[1] * 60 * 1000) + ((+timerDurationSplit[2] * 1000) || 0)
+
+const socket = new WebSocket('ws://127.0.0.1:8000/ws/admin_changes/');
+socket.onmessage = function (event) {
+    console.log('Recieved message: ' + event.data);
+    location.reload();
+};
+socket.onclose = function(event) {
+    // Handle socket closure here
+    console.log('Socket closed with code: ' + event.code);
+};
+
+socket.onerror = function(error) {
+    // Handle any errors here
+    console.error('Socket error: ' + error);
+};
+
 const myCountdown = setInterval(() => {
     const now = new Date().getTime()
 

--- a/timer/consumers.py
+++ b/timer/consumers.py
@@ -1,0 +1,30 @@
+from asgiref.sync import async_to_sync
+from channels.generic.websocket import WebsocketConsumer
+
+class AdminChangeConsumer(WebsocketConsumer):
+    def connect(self):
+        self.group_name = "admin_changes"
+        async_to_sync(self.channel_layer.group_add)(
+            self.group_name,
+            self.channel_name,
+        )
+        self.accept()
+    
+    def disconnect(self, close_code):
+        async_to_sync(self.channel_layer.group_discard)(
+            self.group_name,
+            self.channel_name,
+        )
+    
+    async def receive(self, text_data):
+        try:
+            message_type = int(text_data)
+            # Handle the expected message types here
+            pass
+        except ValueError:
+            pass
+        # Code to handle receiving data from the client
+    
+    def admin_change_notification(self, event):
+        message = event['message']
+        self.send(text_data=message)

--- a/timer/models.py
+++ b/timer/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 from django.urls import reverse
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
 
 # Create your models here.
 
@@ -12,4 +14,16 @@ class Timer(models.Model):
 
     def get_absolute_url(self):
         return reverse('timer:timer-detail', kwargs={'pk': self.pk})
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
     
+        # Send notification to clients
+        channel_layer = get_channel_layer()
+        async_to_sync(channel_layer.group_send)(
+            "admin_changes",  # Group name
+            {
+                "type": "admin_change_notification",
+                "message": "A change was made in the admin.",
+            },
+        )

--- a/timer/routing.py
+++ b/timer/routing.py
@@ -1,0 +1,6 @@
+from django.urls import re_path
+from .consumers import AdminChangeConsumer
+
+websocket_urlpatterns = [
+    re_path(r'ws/admin_changes/$', AdminChangeConsumer.as_asgi()),
+]


### PR DESCRIPTION
When displaying a timer, browser also open a WS connection.
When saving the Timer model, a WS message will be sent to the WS endpoint. Browsers who receive it will then refresh their page, pulling the new data to have up-to-date timers.